### PR TITLE
displayEle Typo Fix

### DIFF
--- a/post.md
+++ b/post.md
@@ -160,7 +160,7 @@ We can also pass through React elements from a parent to a child. This is incred
 
 ```javascript
 Clock.propTypes = {
-  displayEle: React.PropTypes.element
+  displayElement: React.PropTypes.element
 }
 ```
 


### PR DESCRIPTION
Fixing displayEle, changed to displayElement to match the following paragraph