### PR TITLE
Remove the individual class export

### DIFF
--- a/day-16/src/TimeForm.js
+++ b/day-16/src/TimeForm.js
@@ -1,7 +1,7 @@
 import React from "react";
 const timezones = ["PST", "MST", "MDT", "EST", "UTC"];
 
-export class TimeForm extends React.Component {
+class TimeForm extends React.Component {
   constructor(props) {
     super(props);
 


### PR DESCRIPTION
On the 63rd line a default export for the TimeForm component is already declared hence the individual export for the TimeForm component is not needed.